### PR TITLE
Add Centos 7.2 and Fedora 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ This program uses Docker via command line and it works perfectly fine with Docke
 ## * Supported target operating systems
 
 - `Centos 7.1`
+- `Centos 7.2`
 - `Debian Jessie`
 - `Fedora 21`
 - `Fedora 22`
 - `Fedora 23`
+- `Fedora 24`
 - `Ubuntu Precise`
 - `Ubuntu Trusty`
 - `Ubuntu Xenial`

--- a/docker/mesos/centos:7.2/Dockerfile
+++ b/docker/mesos/centos:7.2/Dockerfile
@@ -1,0 +1,16 @@
+FROM centos:7.2.1511
+
+RUN yum install -y wget epel-release \
+    && yum swap -y fakesystemd systemd \
+    && wget http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo \
+    && echo -e '[WANdiscoSVN]\n\
+name=WANdisco SVN Repo 1.9\n\
+enabled=1\n\
+baseurl=http://opensource.wandisco.com/centos/7/svn-1.9/RPMS/$basearch/\n\
+gpgcheck=1\n\
+gpgkey=http://opensource.wandisco.com/RPM-GPG-KEY-WANdisco\n' >> /etc/yum.repos.d/wandisco-svn.repo \
+    && yum groupinstall "Development Tools" -y \
+    && yum install -y apache-maven python-devel python-boto java-1.8.0-openjdk-devel zlib-devel libcurl-devel openssl-devel cyrus-sasl-devel cyrus-sasl-md5 apr-devel subversion-devel apr-util-devel ruby-devel \
+    && gem install fpm --no-ri --no-rdoc
+
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk

--- a/docker/mesos/fedora:24/Dockerfile
+++ b/docker/mesos/fedora:24/Dockerfile
@@ -1,0 +1,20 @@
+FROM fedora:24
+
+RUN dnf install -y which tar wget \
+    && mkdir -p /tmp/maven && cd /tmp/maven \
+    && wget http://mirror.olnevhost.net/pub/apache/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz \
+    && tar xvf apache-maven-3.3.9-bin.tar.gz \
+    && mv apache-maven-3.3.9 /usr/local/apache-maven \
+    && cd / && source /etc/bashrc && rm -rf /tmp/maven \
+    && ln -sf /usr/local/apache-maven/bin/mvn /usr/bin/mvn \
+    && dnf groupinstall "Development Tools" "Development Libraries" -y \
+    && dnf update nss -y \
+    && dnf install -y python-boto libtool redhat-rpm-config gcc-c++ \
+                      java-1.8.0-openjdk-devel cyrus-sasl-md5 \
+                      apr-devel subversion-devel ruby-devel \
+                      rpm-build \
+    && gem install fpm --no-ri --no-rdoc
+
+ENV M2_HOME /usr/local/apache-maven
+ENV M2 /usr/local/apache-maven/bin
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk


### PR DESCRIPTION
However, packaging for Red Hat and Fedora is broken since 22/06/2016 (https://github.com/mesosphere/mesos-deb-packaging/commit/dbad01ce548953f68c631d29d1a82dda1591e502).