### PR TITLE
Fixed rpm/deb packaging for Marathon. HAProxy for Marathon disabled b…

### DIFF
--- a/docker/marathon/default/data/marathon-build.sh
+++ b/docker/marathon/default/data/marathon-build.sh
@@ -3,9 +3,9 @@
 set -e
 
 BUILD_DIR=/marathon-src
-PACKAGING_DIR=/tmp/marathon-packaging
+PACKAGING_DIR=/tmp/fpm-packaging
 ASSEMBLY_WITH_TESTS=${ASSEMBLY_WITH_TESTS-false}
-INCLUDE_HAPROXY_MARATHON_BRIDGE=${INCLUDE_HAPROXY_MARATHON_BRIDGE-true}
+INCLUDE_HAPROXY_MARATHON_BRIDGE=${INCLUDE_HAPROXY_MARATHON_BRIDGE-false}
 
 echo "Creating build directory..."
 
@@ -45,6 +45,7 @@ echo "[MARATHON BUILD]: Preparing RPM package..."
 fpm -s dir -t rpm -n ${BUILD_MARATHON_PACKAGE_NAME} -v ${FPM_OUTPUT_VERSION} -C ${PACKAGING_DIR}
 
 echo "[MARATHON BUILD]: Build ready..."
+
 mkdir -p /output/${BUILD_MARATHON_VERSION}
-mv ${BUILD_DIR}/*.rpm /output/${BUILD_MARATHON_VERSION}
-mv ${BUILD_DIR}/*.deb /output/${BUILD_MARATHON_VERSION}
+mv *.rpm /output/${BUILD_MARATHON_VERSION}
+mv *.deb /output/${BUILD_MARATHON_VERSION}

--- a/lib/configs/marathon_config.py
+++ b/lib/configs/marathon_config.py
@@ -75,7 +75,7 @@ class MarathonConfig(object):
         Config.add_argument( "--no-haproxy-marathon-bridge",
                                 dest="no_haproxy_marathon_bridge",
                                 help="Do not package haproxy-marathon-bridge when packaging Marathon.",
-                                action="store_false" )
+                                action="store_true" )
 
         return Config.ready(program)
 

--- a/marathon-toolbox.py
+++ b/marathon-toolbox.py
@@ -87,8 +87,7 @@ def op_build():
         docker_command.append("{} ".format( image_name ))
         docker_command.append("/bin/bash -c 'cd /marathon-build && ./marathon-build.sh; exit $?'")
         build_command = "".join( docker_command )
-        
-        Utils.cmd("echo '{}'".format(build_command.replace("'", "\\'")))
+        LOG.info("Docker command: {}".format(build_command))
         LOG.info("Building Marathon {}. This will take a while...".format(MarathonConfig.marathon_version()))
         build_start_time = int(time.time())
         build_status = Utils.cmd(build_command)


### PR DESCRIPTION
…y default.

- Marathon `*.rpm/*.deb` were never copied to `builds`.
- Do not package haproxy marathon bridge by default.