### PR TITLE
Fix base docker image for chronos build.

### DIFF
--- a/docker/chronos/default/Dockerfile
+++ b/docker/chronos/default/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.1.1503
+FROM centos:7.3.1611
 
 ADD data /chronos-build
 


### PR DESCRIPTION
Same issue as with Marathon. Centos version had to be updated.